### PR TITLE
added a from_string method to HumanHasher

### DIFF
--- a/humanhash.py
+++ b/humanhash.py
@@ -135,8 +135,20 @@ class HumanHasher(object):
 
         digest = str(uuidlib.uuid4()).replace('-', '')
         return self.humanize(digest, **params), digest
+        
+    def from_string(self, value, **params):
+        
+        """
+        Generate a UUID with a human-readable representation from an input string.
+
+        Returns `human_repr`.  Accepts the same keyword arguments as :meth:`humanize`
+        """
+
+        digest = str(uuidlib.uuid3(uuidlib.NAMESPACE_DNS, value)).replace('-', '')
+        return self.humanize(digest, **params)
 
 
 DEFAULT_HASHER = HumanHasher()
 uuid = DEFAULT_HASHER.uuid
 humanize = DEFAULT_HASHER.humanize
+from_string = DEFAULT_HASHER.from_string


### PR DESCRIPTION
This lets you make calls like:

``` python
>>> humanhash.from_string("humanhash")
'asparagus-oven-minnesota-hamper'
```

Which helped with some of my purposes (needing a human-readable tag for another human-readable string, but for them to be semantically unrelated)
